### PR TITLE
Updated doc string of evalf method in sympy.core.evalf

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1391,6 +1391,32 @@ class EvalfMixin(object):
             verbose=<bool>
                 Print debug information (default=False)
 
+        Note:
+        It is always suggested to use expr.evalf(subs=...) over,
+        expr.subs(...).evalf() or expr.evalf().subs(...) because of the
+        following reasons:-
+
+        i.   expr.evalf(subs=...) avoids the loss of significance caused due to
+             naive subtitution;
+        ii.  expr.evalf(subs=...) the expression is run throught the evalf algorithm,
+             which takes into account various issues that can leade to loss of
+             significance.
+        iii. The subs dictionary tells the evalf algorithms which symbols should be
+             replaced with numbers when they are encountered.
+
+        Example
+        -------
+        >>> from sympy.core.evalf import evalf
+        >>> from sympy.abc import x,y,z
+        >>> (x+y-z).subs({x:1e100,y:1,z:1e100}) #case_1
+        >>> 0
+        >>> (x+y-z).evalf(subs={x: 1e100, y: 1, z: 1e100}) #case_2
+        >>> 1.00000000000000
+
+        In the above example, in #case_1, naive substitution evaluates 1e100 + 1 - 1e100
+        which looses 1 because the default precesion setting. However, in #case_2, the
+        evalf algorithm takes care of the significance.
+
         """
         from sympy import Float, Number
         n = n if n is not None else 15


### PR DESCRIPTION
Updated doc string evalf method in sympy.core.evalf

Fixes #14732
See, https://github.com/sympy/sympy/issues/14732

I have updated the doc string method in sympy.core.evalf so that it becomes clear why should we use expr.evalf(subs=...) over expr.evalf().subs(...) or expr.subs(...).evalf().
 
